### PR TITLE
fix: organize error messages

### DIFF
--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -165,7 +165,7 @@ func (f *Filesystem) setRepoDir() error {
 	var p = path.Join(f.Endpoint, constants.OlaresStorageDefaultPrefix, fmt.Sprintf("%s-%s", f.RepoName, f.RepoId))
 	if !utils.IsExist(p) {
 		if err := utils.CreateDir(p); err != nil {
-			return err
+			return errors.New("Failed to create backup folder. Please check your permissions.")
 		}
 		return nil
 	}


### PR DESCRIPTION
**Background**
1. error message consolidation

2. the mode for extracting backup size has been adjusted to raw-data. The raw-data mode calculates the total size of all blobs in the current backup. This size does not exactly equal the actual storage size used in the cloud because all blobs are distributed and stored within pack files. Pack files are the actual storage units in the cloud, containing the blob data as well as metadata such as blob offsets. Therefore, the actual cloud storage size is slightly larger than the total size of the blobs.