### PR TITLE
fix: check the remaining disk space

### DIFF
--- a/pkg/storage/filesystem/filesystem.go
+++ b/pkg/storage/filesystem/filesystem.go
@@ -52,6 +52,7 @@ func (f *Filesystem) Backup(ctx context.Context, dryRun bool, progressCallback f
 		BackupType:               f.BackupType,
 		BackupAppTypeName:        f.BackupAppTypeName,
 		BackupFileTypeSourcePath: f.BackupFileTypeSourcePath,
+		LocalEndpoint:            f.Endpoint,
 		RepoEnvs:                 envs,
 	}
 


### PR DESCRIPTION
During the restore and backup processes, the disk usage is checked periodically. If it exceeds 85%, the task will be stopped and a message indicating insufficient disk space will be returned